### PR TITLE
allow mtime to be set

### DIFF
--- a/eg/Mostly-Auto.yml
+++ b/eg/Mostly-Auto.yml
@@ -1,3 +1,4 @@
 --- #YAML:1.0
 name: Mostly-Auto
 abstract: nothing to see here
+mtime: 100

--- a/lib/Module/Faker/Dist.pm
+++ b/lib/Module/Faker/Dist.pm
@@ -22,6 +22,7 @@ has abstract     => (is => 'ro', isa => 'Str', default => 'a great new dist');
 has cpan_author  => (is => 'ro', isa => 'Maybe[Str]', default => 'LOCAL');
 has archive_ext  => (is => 'ro', isa => 'Str', default => 'tar.gz');
 has append       => (is => 'ro', isa => 'ArrayRef[HashRef]', default => sub {[]});
+has mtime        => (is => 'ro', isa => 'Int', predicate => 'has_mtime');
 
 sub append_for {
   my ($self, $filename) = @_;
@@ -179,7 +180,7 @@ sub make_archive {
 
   $self->_mk_container_path($archive_filename);
   $archive->write_file($archive_filename);
-
+  utime time, $self->mtime, $archive_filename if $self->has_mtime;
   return $archive_filename;
 }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -20,6 +20,9 @@ ok(
   "we got the mostly-auto dist",
 );
 
+
+is((stat("$tmpdir/Mostly-Auto-0.01.tar.gz"))[9], 100, "got mtime set");
+
 subtest "from YAML file" => sub {
   my $dist = Module::Faker::Dist->from_file('./eg/RJBS-Dist.yml');
   is($dist->cpan_author, 'RJBS', "get cpan author from Faker META section");


### PR DESCRIPTION
we run into problems with our metacpan test suite because all tarballs are created in the same second. Which makes it impossible to test for "what was uploaded first".
