### PR TITLE
Remove the // operator so we can support perls before 5.10

### DIFF
--- a/lib/Module/Faker/Dist.pm
+++ b/lib/Module/Faker/Dist.pm
@@ -1,6 +1,6 @@
 package Module::Faker::Dist;
 use Moose;
-use 5.10.0;
+
 # ABSTRACT: a fake CPAN distribution
 
 use Module::Faker::File;
@@ -24,6 +24,8 @@ has archive_ext  => (is => 'ro', isa => 'Str', default => 'tar.gz');
 has append       => (is => 'ro', isa => 'ArrayRef[HashRef]', default => sub {[]});
 has mtime        => (is => 'ro', isa => 'Int', predicate => 'has_mtime');
 
+sub __dor { defined $_[0] ? $_[0] : $_[1] }
+
 sub append_for {
   my ($self, $filename) = @_;
   return [
@@ -40,7 +42,7 @@ has archive_basename => (
   lazy => 1,
   default => sub {
     my ($self) = @_;
-    return sprintf '%s-%s', $self->name, $self->version // 'undef';
+    return sprintf '%s-%s', $self->name, __dor($self->version, 'undef');
   },
 );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -36,4 +36,11 @@ subtest "from .dist file" => sub {
   is($dist->version, '1.24', "correct version");
 };
 
+subtest "from struct, with undef version" => sub {
+  my $dist = Module::Faker::Dist->new({name => 'Some-Dist', version => undef});
+  is($dist->name, 'Some-Dist', "correct dist name");
+  is($dist->version, undef, "correct version");
+  is($dist->archive_basename, 'Some-Dist-undef', "correct basename");
+};
+
 done_testing;


### PR DESCRIPTION
Also added test case to cover our home-grown __dor() function.  I can't test this with dzil on 5.8.9 because some of your author plugins require 5.10.  But here's the output from prove on 5.8.9:

``` bash
(1943)[jeff@callahan:Module-Faker]$ perl -e 'print "$]\n"';
5.008009
(1944)[jeff@callahan:Module-Faker]$ prove -l t
t/append-utf8.t .... ok   
t/append.t ......... ok   
t/basic.t .......... ok   
t/omit-file.t ...... ok   
t/provide-order.t .. ok   
t/requires.t ....... ok   
All tests successful.
Files=6, Tests=20,  4 wallclock secs ( 0.05 usr  0.02 sys +  3.62 cusr  0.25 csys =  3.94 CPU)
Result: PASS
```
